### PR TITLE
Add editable templates

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import RecipientForm from './components/RecipientForm';
@@ -6,19 +6,33 @@ import TemplateSelector from './components/TemplateSelector';
 import EmailPreview from './components/EmailPreview';
 import SendButton from './components/SendButton';
 import SuccessModal from './components/SuccessModal';
-import { emailTemplates } from './data/emailTemplates';
+import TemplateEditor from './components/TemplateEditor';
+import { useEmailTemplates } from './hooks/useEmailTemplates';
 import { Recipient } from './types';
 
 function App() {
+  const { templates, addTemplate, updateTemplate, deleteTemplate } =
+    useEmailTemplates();
+
   const [recipient, setRecipient] = useState<Recipient>({
     firstName: '',
     email: ''
   });
-  
-  const [selectedTemplateId, setSelectedTemplateId] = useState(emailTemplates[0].id);
+
+  const [selectedTemplateId, setSelectedTemplateId] = useState(
+    templates[0]?.id || ''
+  );
   const [showSuccessModal, setShowSuccessModal] = useState(false);
-  
-  const selectedTemplate = emailTemplates.find(template => template.id === selectedTemplateId) || emailTemplates[0];
+
+  useEffect(() => {
+    if (templates.length && !templates.find(t => t.id === selectedTemplateId)) {
+      setSelectedTemplateId(templates[0].id);
+    }
+  }, [templates, selectedTemplateId]);
+
+  const selectedTemplate =
+    templates.find(template => template.id === selectedTemplateId) ||
+    templates[0];
   
   const isFormValid = () => {
     const isEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(recipient.email);
@@ -60,8 +74,8 @@ function App() {
                 onChange={setRecipient} 
               />
               
-              <TemplateSelector 
-                templates={emailTemplates}
+              <TemplateSelector
+                templates={templates}
                 selectedTemplateId={selectedTemplateId}
                 onSelect={setSelectedTemplateId}
               />
@@ -73,8 +87,15 @@ function App() {
             />
           </div>
           
+          <TemplateEditor
+            templates={templates}
+            onAdd={addTemplate}
+            onUpdate={updateTemplate}
+            onDelete={deleteTemplate}
+          />
+
           <div className="flex justify-center mt-8">
-            <SendButton 
+            <SendButton
               recipient={recipient}
               isValid={isFormValid()}
               onSend={handleSend}

--- a/project/src/components/TemplateEditor.tsx
+++ b/project/src/components/TemplateEditor.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { EmailTemplate } from '../types';
+
+interface TemplateEditorProps {
+  templates: EmailTemplate[];
+  onAdd: (template: Omit<EmailTemplate, 'id'>) => void;
+  onUpdate: (id: string, template: EmailTemplate) => void;
+  onDelete: (id: string) => void;
+}
+
+const TemplateEditor: React.FC<TemplateEditorProps> = ({
+  templates,
+  onAdd,
+  onUpdate,
+  onDelete
+}) => {
+  const [newTemplate, setNewTemplate] = useState<Omit<EmailTemplate, 'id'>>({
+    name: '',
+    subject: '',
+    body: ''
+  });
+
+  const handleAdd = () => {
+    if (!newTemplate.name.trim()) return;
+    onAdd(newTemplate);
+    setNewTemplate({ name: '', subject: '', body: '' });
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 space-y-4">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+        Gestion des modèles
+      </h2>
+      {templates.map(template => (
+        <div key={template.id} className="space-y-2 border-b pb-4 mb-4">
+          <input
+            type="text"
+            value={template.name}
+            onChange={e =>
+              onUpdate(template.id, { ...template, name: e.target.value })
+            }
+            className="w-full px-3 py-1 border rounded-md dark:bg-gray-700"
+          />
+          <input
+            type="text"
+            value={template.subject}
+            onChange={e =>
+              onUpdate(template.id, { ...template, subject: e.target.value })
+            }
+            className="w-full px-3 py-1 border rounded-md dark:bg-gray-700"
+          />
+          <textarea
+            value={template.body}
+            onChange={e =>
+              onUpdate(template.id, { ...template, body: e.target.value })
+            }
+            className="w-full px-3 py-1 border rounded-md dark:bg-gray-700"
+          />
+          <button
+            onClick={() => onDelete(template.id)}
+            className="text-red-600 text-sm"
+          >
+            Supprimer
+          </button>
+        </div>
+      ))}
+      <div className="space-y-2">
+        <input
+          type="text"
+          placeholder="Nom"
+          value={newTemplate.name}
+          onChange={e => setNewTemplate({ ...newTemplate, name: e.target.value })}
+          className="w-full px-3 py-1 border rounded-md dark:bg-gray-700"
+        />
+        <input
+          type="text"
+          placeholder="Sujet"
+          value={newTemplate.subject}
+          onChange={e =>
+            setNewTemplate({ ...newTemplate, subject: e.target.value })
+          }
+          className="w-full px-3 py-1 border rounded-md dark:bg-gray-700"
+        />
+        <textarea
+          placeholder="Contenu"
+          value={newTemplate.body}
+          onChange={e => setNewTemplate({ ...newTemplate, body: e.target.value })}
+          className="w-full px-3 py-1 border rounded-md dark:bg-gray-700"
+        />
+        <button
+          onClick={handleAdd}
+          className="bg-amber-500 text-white px-4 py-2 rounded-md"
+        >
+          Ajouter
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TemplateEditor;

--- a/project/src/hooks/useEmailTemplates.ts
+++ b/project/src/hooks/useEmailTemplates.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { EmailTemplate } from '../types';
+import { emailTemplates as defaultTemplates } from '../data/emailTemplates';
+
+const STORAGE_KEY = 'emailTemplates';
+
+export const useEmailTemplates = () => {
+  const [templates, setTemplates] = useState<EmailTemplate[]>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        return JSON.parse(stored) as EmailTemplate[];
+      } catch {
+        return defaultTemplates;
+      }
+    }
+    return defaultTemplates;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+  }, [templates]);
+
+  const addTemplate = (template: Omit<EmailTemplate, 'id'>) => {
+    const newTemplate: EmailTemplate = {
+      ...template,
+      id: Date.now().toString()
+    };
+    setTemplates(prev => [...prev, newTemplate]);
+  };
+
+  const updateTemplate = (id: string, updated: EmailTemplate) => {
+    setTemplates(prev => prev.map(t => (t.id === id ? { ...updated } : t)));
+  };
+
+  const deleteTemplate = (id: string) => {
+    setTemplates(prev => prev.filter(t => t.id !== id));
+  };
+
+  return { templates, addTemplate, updateTemplate, deleteTemplate };
+};
+


### PR DESCRIPTION
## Summary
- manage templates in `localStorage`
- create CRUD component for email templates
- update app to use editable templates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415c69cd00832b83f57f3bfc160841