### PR TITLE
Add Vitest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Automatisation-email
+
+Ce projet contient une application React permettant d'automatiser l'envoi d'emails. Toutes les sources se trouvent dans le dossier `project`.
+
+## Lancer les tests unitaires
+
+Les tests utilisent [Vitest](https://vitest.dev/) et React Testing Library.
+
+```bash
+cd project
+npm run test
+```
+

--- a/project/package.json
+++ b/project/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -28,6 +29,10 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }

--- a/project/src/components/__tests__/RecipientForm.test.tsx
+++ b/project/src/components/__tests__/RecipientForm.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RecipientForm from '../RecipientForm';
+import { Recipient } from '../../types';
+
+const setup = (recipient: Recipient = { firstName: '', email: '' }) => {
+  const handleChange = vi.fn();
+  render(<RecipientForm recipient={recipient} onChange={handleChange} />);
+  return { handleChange };
+};
+
+describe('RecipientForm', () => {
+  it('calls onChange when first name changes', async () => {
+    const user = userEvent.setup();
+    const { handleChange } = setup();
+    const input = screen.getByLabelText(/prénom/i);
+    await user.type(input, 'John');
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('calls onChange when email changes', async () => {
+    const user = userEvent.setup();
+    const { handleChange } = setup();
+    const input = screen.getByLabelText(/adresse email/i);
+    await user.type(input, 'test@example.com');
+    expect(handleChange).toHaveBeenCalled();
+  });
+});

--- a/project/src/components/__tests__/SendButton.test.tsx
+++ b/project/src/components/__tests__/SendButton.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SendButton from '../SendButton';
+import { Recipient } from '../../types';
+
+const renderButton = (recipient: Recipient, isValid: boolean, onSend = vi.fn()) => {
+  render(<SendButton recipient={recipient} isValid={isValid} onSend={onSend} />);
+  return onSend;
+};
+
+describe('SendButton', () => {
+  it('displays email validation error', () => {
+    renderButton({ firstName: 'John', email: 'invalid' }, false);
+    expect(screen.getByText(/adresse email valide/i)).toBeInTheDocument();
+  });
+
+  it("displays first name error when missing", () => {
+    renderButton({ firstName: '', email: 'test@example.com' }, false);
+    expect(screen.getByText(/prénom du destinataire/i)).toBeInTheDocument();
+  });
+
+  it('calls onSend when valid and clicked', async () => {
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onSend = renderButton({ firstName: 'John', email: 'test@example.com' }, true);
+    await user.click(screen.getByRole('button'));
+    vi.advanceTimersByTime(1500);
+    expect(onSend).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/project/src/components/__tests__/TemplateSelector.test.tsx
+++ b/project/src/components/__tests__/TemplateSelector.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TemplateSelector from '../TemplateSelector';
+import { EmailTemplate } from '../../types';
+
+const templates: EmailTemplate[] = [
+  { id: '1', name: 'A', subject: 'A subject', body: 'Body A' },
+  { id: '2', name: 'B', subject: 'B subject', body: 'Body B' }
+];
+
+describe('TemplateSelector', () => {
+  it('calls onSelect when a template is clicked', async () => {
+    const user = userEvent.setup();
+    const handleSelect = vi.fn();
+    render(
+      <TemplateSelector templates={templates} selectedTemplateId="1" onSelect={handleSelect} />
+    );
+    await user.click(screen.getByText('B'));
+    expect(handleSelect).toHaveBeenCalledWith('2');
+  });
+
+  it('highlights the selected template', () => {
+    const handleSelect = vi.fn();
+    render(
+      <TemplateSelector templates={templates} selectedTemplateId="2" onSelect={handleSelect} />
+    );
+    const selected = screen.getByText('B').closest('div');
+    expect(selected).toHaveClass('bg-amber-50', { exact: false });
+  });
+});

--- a/project/src/setupTests.ts
+++ b/project/src/setupTests.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom';
+

--- a/project/vite.config.ts
+++ b/project/vite.config.ts
@@ -7,4 +7,9 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts'
+  },
 });


### PR DESCRIPTION
## Summary
- add npm test script and testing libraries
- configure vitest in `vite.config.ts`
- add jest-dom setup
- document how to run the tests
- add tests for `RecipientForm`, `TemplateSelector` and `SendButton`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415c6c8750832bb916814ad29244a5