### PR TITLE
Configure from address via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ npm run build     # génère la version de production
 npm run lint      # vérifie le code avec ESLint
 ```
 
+## Configuration
+
+Copiez le fichier `.env.example` présent dans le dossier `project` et renommez-le
+en `.env`. Renseignez votre clé d'API SendGrid dans `VITE_SENDGRID_API_KEY`.
+Vous pouvez également définir `VITE_SENDGRID_FROM_EMAIL` pour modifier l'adresse
+d'expéditeur utilisée par défaut.
+
 ## Structure des dossiers
 
 - `src/components` : composants React utilisés par l'application (en-tête, formulaire, aperçu, etc.).

--- a/project/.env.example
+++ b/project/.env.example
@@ -1,0 +1,2 @@
+VITE_SENDGRID_API_KEY=
+VITE_SENDGRID_FROM_EMAIL=no-reply@example.com

--- a/project/src/api/sendEmail.ts
+++ b/project/src/api/sendEmail.ts
@@ -6,6 +6,8 @@ export async function sendEmail(recipient: Recipient, template: EmailTemplate): 
     throw new Error('SendGrid API key is missing');
   }
 
+  const fromEmail = import.meta.env.VITE_SENDGRID_FROM_EMAIL || 'no-reply@example.com';
+
   const content = template.body.replace(/{{firstName}}/g, recipient.firstName);
 
   const payload = {
@@ -16,7 +18,7 @@ export async function sendEmail(recipient: Recipient, template: EmailTemplate): 
       }
     ],
     from: {
-      email: 'no-reply@example.com',
+      email: fromEmail,
       name: 'EmailPro'
     },
     content: [


### PR DESCRIPTION
## Summary
- allow SendGrid from address to be configured via VITE_SENDGRID_FROM_EMAIL
- document environment variables
- add `.env.example`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68415ec11980832ba8f58f9015117af5