### PR TITLE
Add env example and clarify README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Exemple de configuration environnementale
+# Copiez ce fichier vers project/.env puis renseignez vos valeurs
+VITE_SENDGRID_API_KEY=
+VITE_SENDGRID_FROM_EMAIL=no-reply@example.com

--- a/README.md
+++ b/README.md
@@ -15,10 +15,19 @@ npm run lint      # vérifie le code avec ESLint
 
 ## Configuration
 
-Copiez le fichier `.env.example` présent dans le dossier `project` et renommez-le
-en `.env`. Renseignez votre clé d'API SendGrid dans `VITE_SENDGRID_API_KEY`.
-Vous pouvez également définir `VITE_SENDGRID_FROM_EMAIL` pour modifier l'adresse
-d'expéditeur utilisée par défaut.
+Un fichier `.env.example` est fourni à la racine du dépôt. Copiez-le dans le
+dossier `project` sous le nom `.env` :
+
+```bash
+cp .env.example project/.env
+```
+
+Renseignez ensuite les variables suivantes :
+
+- `VITE_SENDGRID_API_KEY` : votre clé d'API SendGrid (obligatoire pour envoyer
+  des e-mails).
+- `VITE_SENDGRID_FROM_EMAIL` : adresse d'expéditeur utilisée par défaut
+  (optionnelle).
 
 ## Structure des dossiers
 


### PR DESCRIPTION
## Summary
- document environment variables in README
- include an `.env.example` at repo root

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68415ff4ad38832bab9d8cc0f13661b3