### PR TITLE
Add env typings for SendGrid

### DIFF
--- a/project/src/vite-env.d.ts
+++ b/project/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SENDGRID_API_KEY: string;
+  readonly VITE_SENDGRID_FROM_EMAIL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- define SendGrid env variables in `vite-env.d.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841626e1240832bb64dfb26e530da11